### PR TITLE
A Rough Draft of the Base

### DIFF
--- a/src/hypxiel_api_python/hypixel.py
+++ b/src/hypxiel_api_python/hypixel.py
@@ -1,0 +1,7 @@
+# Cache clearing needs to be implemented, create a function for it?
+
+class HypixelAPI:
+    """Represents the main class. This will store the API key and cached data"""
+    def __init__(self, key):
+        self.key = key
+        self.endpoints = {}

--- a/src/hypxiel_api_python/hypixel.py
+++ b/src/hypxiel_api_python/hypixel.py
@@ -4,4 +4,6 @@ class HypixelAPI:
     """Represents the main class. This will store the API key and cached data"""
     def __init__(self, key):
         self.key = key
+        self.path = "https://api.hypixel.net/"
         self.endpoints = {}
+

--- a/src/hypxiel_api_python/player.py
+++ b/src/hypxiel_api_python/player.py
@@ -3,11 +3,11 @@ from math import sqrt
 
 
 class HypixelPlayer:
-    def __init__(self):
-        pass
+    def __init__(self, hypixel_api):
+        self.hypixel_api = hypixel_api
 
-    async def network_level(self):
-        player = await get(endpoint="player")
+    async def network_level(self, uuid):
+        player = await get(self, endpoint="player", param=("uuid", uuid))
         network_experience = player["player"]["networkExp"] if "networkExp" in player["player"] else 0
         network_level = (sqrt((2 * network_experience) + 30625) / 50) - 2.5 if network_experience != 0 else 1
         return network_level

--- a/src/hypxiel_api_python/player.py
+++ b/src/hypxiel_api_python/player.py
@@ -1,0 +1,13 @@
+from src.hypxiel_api_python.utils.requests import get
+from math import sqrt
+
+
+class HypixelPlayer:
+    def __init__(self):
+        pass
+
+    async def network_level(self):
+        player = await get(endpoint="player")
+        network_experience = player["player"]["networkExp"] if "networkExp" in player["player"] else 0
+        network_level = (sqrt((2 * network_experience) + 30625) / 50) - 2.5 if network_experience != 0 else 1
+        return network_level

--- a/src/hypxiel_api_python/utils/requests.py
+++ b/src/hypxiel_api_python/utils/requests.py
@@ -1,25 +1,25 @@
 from aiohttp import ClientSession
-# probably need to add a datetime import eventually
-# import HypixelAPI object
+from datetime import datetime
 
 
-async def get(endpoint: str, nocache: bool = None):
-    """This function will determine whether it should use a cached object or fetch a new one."""
+async def get(self, endpoint: str, param: tuple, nocache: bool = None):
+    api = self.hypixel_api
+    """Determine whether it should use a cached object or fetch a new one."""
     """`nocache` is a way for the user to bypass the cache"""
-    # need to factor in necessary data, e.g. getting/storing a specific request for a UUID rather than the
-    # endpoint itself (currently represented as `object` in pseudocode)
+    cached_value = self.hypixel_api.endpoints[param][endpoint.replace("/", "")]
+    if not cached_value:
+        return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
 
-    # if endpoint not in cached endpoints or object not in endpoints[endpoint]:
-    #    # await fetch
-    # elif x time has passed since it was cached or nocache:
-    #   await fetch
-    # else:
-    #    return endpoints[endpoint]
-    pass
+    elif cached_value["hypixel-api-python"]["timestamp"] + 60 > int(datetime.now().timestamp()) or nocache:
+        return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
+
+    else:
+        return cached_value
 
 
-async def fetch(url: str):
-    """This function fetches data from the Hypixel API"""
+async def fetch(self, url: str):
+    """Fetches data from the Hypixel API"""
+    api = self.hypixel_api
     async with ClientSession() as session:
         async with session.get(url) as request:
 

--- a/src/hypxiel_api_python/utils/requests.py
+++ b/src/hypxiel_api_python/utils/requests.py
@@ -1,0 +1,34 @@
+from aiohttp import ClientSession
+# probably need to add a datetime import eventually
+# import HypixelAPI object
+
+
+async def get(endpoint: str, nocache: bool = None):
+    """This function will determine whether it should use a cached object or fetch a new one."""
+    """`nocache` is a way for the user to bypass the cache"""
+    # need to factor in necessary data, e.g. getting/storing a specific request for a UUID rather than the
+    # endpoint itself (currently represented as `object` in pseudocode)
+
+    # if endpoint not in cached endpoints or object not in endpoints[endpoint]:
+    #    # await fetch
+    # elif x time has passed since it was cached or nocache:
+    #   await fetch
+    # else:
+    #    return endpoints[endpoint]
+    pass
+
+
+async def fetch(url: str):
+    """This function fetches data from the Hypixel API"""
+    async with ClientSession() as session:
+        async with session.get(url) as request:
+
+            # ratelimited
+            if request.status == 429:
+                # add handling for ratelimiting
+                pass
+            elif request.status == 200:
+                # store in cache
+                # check if it's successful
+                return request.json()
+            # add more status codes and else statement


### PR DESCRIPTION
This fork implements an intrinsic caching method for endpoints, where `get` is called with non-bulky parameters that can call `fetch` if the cache is insufficient. This is only a rough draft, so this isn't completely functional.