### PR TITLE
Refactor of #8 to use paramethers and headers

### DIFF
--- a/src/hypxiel_api_python/hypixel.py
+++ b/src/hypxiel_api_python/hypixel.py
@@ -5,5 +5,4 @@ class HypixelAPI:
     def __init__(self, key):
         self.key = key
         self.path = "https://api.hypixel.net/"
-        self.endpoints = {}
-
+        self.request_cache = {}

--- a/src/hypxiel_api_python/hypixel.py
+++ b/src/hypxiel_api_python/hypixel.py
@@ -1,8 +1,11 @@
 # Cache clearing needs to be implemented, create a function for it?
 
+
 class HypixelAPI:
     """Represents the main class. This will store the API key and cached data"""
+
     def __init__(self, key):
         self.key = key
         self.path = "https://api.hypixel.net/"
         self.request_cache = {}
+        self.ratelimit_info = {}

--- a/src/hypxiel_api_python/player.py
+++ b/src/hypxiel_api_python/player.py
@@ -6,8 +6,26 @@ class HypixelPlayer:
     def __init__(self, hypixel_api):
         self.hypixel_api = hypixel_api
 
+    # support for names needs to be added
     async def network_level(self, uuid):
         player = await get(self, endpoint="player", param=("uuid", uuid))
         network_experience = player["player"]["networkExp"] if "networkExp" in player["player"] else 0
         network_level = (sqrt((2 * network_experience) + 30625) / 50) - 2.5 if network_experience != 0 else 1
         return network_level
+
+    async def rank(self, uuid):
+        player = await get(self, endpoint="player", param=("uuid", uuid))
+        if "rank" in player["player"] and not player["player"]["rank"] == "NORMAL":
+            return player["player"]["rank"]
+
+        elif "monthlyPackageRank" in player["player"] and not \
+                player["player"]["monthlyPackageRank"] == "NONE":
+            return player["player"]["monthlyPackageRank"]
+
+        elif "newPackageRank" in player["player"]:
+            return player["player"]["newPackageRank"]
+
+        elif "packageRank" in player["player"]:
+            return player["player"]["packageRank"]
+        else:
+            return None

--- a/src/hypxiel_api_python/utils/cache.py
+++ b/src/hypxiel_api_python/utils/cache.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+# This is currently only set up to purge values that can't be cached for long, e.g. a hypixel player
+# Support will need to be added for name caching
+
+
+async def purge_cache(self):
+    """Purges the cache of old data"""
+    requests = self.request_cache
+    for key in requests:
+        if requests[key]["hypixel-api-python"]["timestamp"] + 60 < int(datetime.now().timestamp()):
+            del requests[key]

--- a/src/hypxiel_api_python/utils/cache.py
+++ b/src/hypxiel_api_python/utils/cache.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-
+from src.hypxiel_api_python.hypixel import HypixelAPI
 
 # This is currently only set up to purge values that can't be cached for long, e.g. a hypixel player
 # Support will need to be added for name caching
 
 
-async def purge_cache(hypixel_api, /, *, force=False) -> None:
+async def purge_cache(hypixel_api: HypixelAPI, *, force=False) -> None:
     """
     It purges the cache of old data
 
@@ -19,6 +19,8 @@ async def purge_cache(hypixel_api, /, *, force=False) -> None:
         hypixel_api.request_cache = {}
         return
     for key in requests:
-        if requests[key]["hypixel-api-python"]["timestamp"] + 60 < int(datetime.now().timestamp()):
+        if requests[key]["hypixel-api-python"]["timestamp"] + 60 < int(
+            datetime.now().timestamp()
+        ):
             del requests[key]
     return

--- a/src/hypxiel_api_python/utils/cache.py
+++ b/src/hypxiel_api_python/utils/cache.py
@@ -1,12 +1,24 @@
 from datetime import datetime
 
+
 # This is currently only set up to purge values that can't be cached for long, e.g. a hypixel player
 # Support will need to be added for name caching
 
 
-async def purge_cache(self):
+async def purge_cache(hypixel_api, /, *, force=False) -> None:
+    """
+    It purges the cache of old data
+
+    :param hypixel_api: The HypixelAPI object
+    :param force: If set to True, it will purge the entire cache. If set to False, it will purge the cache of old data, defaults to False (optional)
+    :return: None
+    """
     """Purges the cache of old data"""
-    requests = self.request_cache
+    requests = hypixel_api.request_cache
+    if force:
+        hypixel_api.request_cache = {}
+        return
     for key in requests:
         if requests[key]["hypixel-api-python"]["timestamp"] + 60 < int(datetime.now().timestamp()):
             del requests[key]
+    return

--- a/src/hypxiel_api_python/utils/requests.py
+++ b/src/hypxiel_api_python/utils/requests.py
@@ -38,13 +38,13 @@ async def get(
         or cached_response["hypixel-api-python"]["timestamp"] + expiration_time > int(datetime.now().timestamp())
         or nocache
     ):
-        return await fetch_hypxiel_api(hypixel_api, endpoint, params, auth_header)
+        return await fetch(hypixel_api, endpoint, params, auth_header)
 
     else:
         return cached_response["response"]
 
 
-async def fetch_hypxiel_api(
+async def fetch(
         hypixel_api: HypixelAPI,
         endpoint: str,
         params: dict[str, str],

--- a/src/hypxiel_api_python/utils/requests.py
+++ b/src/hypxiel_api_python/utils/requests.py
@@ -1,48 +1,63 @@
-from src.hypxiel_api_python.utils.cache import purge_cache
-from urllib.parse import urlparse, parse_qs
-from aiohttp import ClientSession
 from datetime import datetime
+from aiohttp import ClientSession
+from src.hypxiel_api_python.utils.cache import purge_cache
+from src.hypxiel_api_python.hypixel import HypixelAPI
 
 
-async def get(self, endpoint: str, param: tuple, nocache: bool = None):
+async def get(hypixel_api: HypixelAPI, endpoint: str, params: dict[str, str], nocache: bool = None) -> dict:
     """Determine whether it should use a cached object or fetch a new one."""
     """`nocache` is a way for the user to bypass the cache"""
-    await purge_cache(self)
-    api = self.hypixel_api
-    cached_response = self.hypixel_api.request_cache[param][f"{endpoint.replace('/', '')}.{param[1]}"]
-    if not cached_response:
-        return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
+    if not endpoint.startswith("/"):
+        endpoint = f"/{endpoint}"
 
-    elif cached_response["hypixel-api-python"]["timestamp"] + 60 > int(datetime.now().timestamp()) or nocache:
-        return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
+    await purge_cache(hypixel_api)
+    auth_header = {"API-Key": hypixel_api.key}
+    try:
+        cached_response = hypixel_api.request_cache[f"{endpoint}.{params}"]
+        # print(cached_response)
+    except KeyError:
+        cached_response = None
+    # if not cached_response:
+    #     return await fetch(self, endpoint, params, auth_header)
+    if not cached_response or cached_response["hypixel-api-python"]["timestamp"] + 60 > int(datetime.now().timestamp()) or nocache:
+        return await fetch_hypxiel_api(hypixel_api, endpoint, params, auth_header)
 
     else:
         return cached_response["response"]
 
 
-async def fetch(self, url: str):
-    """Fetches data from the Hypixel API"""
-    # stored as variables for readability
-    parsed = urlparse(url)
-    params = parse_qs(parsed.query)
-    param_name = list(params.keys())[1]
-    param_value = params[param_name][0]
+async def fetch_hypxiel_api(hypixel_api: HypixelAPI, endpoint: str, params: dict[str, str], headers: dict[str, str]) -> dict:
+    """
+    Fetches data from the Hypixel API and returns it as a dictionary
 
-    api = self.hypixel_api
-    async with ClientSession() as session:
-        async with session.get(url) as request:
+    :param hypixel_api: The HypixelAPI object
+    :param endpoint: The endpoint you want to fetch data from
+    :type endpoint: str
+    :param params: The parameters to send to the API
+    :type params: dict[str, str]
+    :param headers: The headers that are sent with the request
+    :type headers: dict[str, str]
+    :return: A dictionary containing the response from the Hypixel API.
+    """
+    HYPIXEL_API_URL = "https://api.hypixel.net"
 
+    async with ClientSession(HYPIXEL_API_URL, headers=headers) as session:
+        async with session.get(endpoint, params=params) as request:
+            ratelimit_info = {x: y for x, y in request.headers.items() if x.startswith("RateLimit-")}
             # ratelimit
+            print(request.status)
             if request.status == 429:
                 # add handling for ratelimiting
                 pass
             elif request.status == 200:
                 # check if it's successful
-                api.request_cache[f"{parsed.path.replace('/', '')}.{[param_value]}"] = {
-                    "response": request.json(),
+                response = await request.json()
+                hypixel_api.request_cache[f"{endpoint}.{params}"] = {
+                    "response": response,
                     "hypixel-api-python": {
                         "timestamp": int(datetime.now().timestamp())
                     }
                 }
-                return request.json()
+                hypixel_api.ratelimit_info = ratelimit_info
+                return response
             # add more status codes and else statement

--- a/src/hypxiel_api_python/utils/requests.py
+++ b/src/hypxiel_api_python/utils/requests.py
@@ -1,34 +1,48 @@
+from src.hypxiel_api_python.utils.cache import purge_cache
+from urllib.parse import urlparse, parse_qs
 from aiohttp import ClientSession
 from datetime import datetime
 
 
 async def get(self, endpoint: str, param: tuple, nocache: bool = None):
-    api = self.hypixel_api
     """Determine whether it should use a cached object or fetch a new one."""
     """`nocache` is a way for the user to bypass the cache"""
-    cached_value = self.hypixel_api.endpoints[param][endpoint.replace("/", "")]
-    if not cached_value:
+    await purge_cache(self)
+    api = self.hypixel_api
+    cached_response = self.hypixel_api.request_cache[param][f"{endpoint.replace('/', '')}.{param[1]}"]
+    if not cached_response:
         return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
 
-    elif cached_value["hypixel-api-python"]["timestamp"] + 60 > int(datetime.now().timestamp()) or nocache:
+    elif cached_response["hypixel-api-python"]["timestamp"] + 60 > int(datetime.now().timestamp()) or nocache:
         return await fetch(self=self, url=f"{api.path}/{endpoint}?key={api.key}&{param[0]}={param[1]}")
 
     else:
-        return cached_value
+        return cached_response["response"]
 
 
 async def fetch(self, url: str):
     """Fetches data from the Hypixel API"""
+    # stored as variables for readability
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    param_name = list(params.keys())[1]
+    param_value = params[param_name][0]
+
     api = self.hypixel_api
     async with ClientSession() as session:
         async with session.get(url) as request:
 
-            # ratelimited
+            # ratelimit
             if request.status == 429:
                 # add handling for ratelimiting
                 pass
             elif request.status == 200:
-                # store in cache
                 # check if it's successful
+                api.request_cache[f"{parsed.path.replace('/', '')}.{[param_value]}"] = {
+                    "response": request.json(),
+                    "hypixel-api-python": {
+                        "timestamp": int(datetime.now().timestamp())
+                    }
+                }
                 return request.json()
             # add more status codes and else statement


### PR DESCRIPTION
Forked this from https://github.com/HoggyTheWizard/hypixel-api-python/tree/27f8512abe825ad30abaf76abbfd3c1443158ba6 because #8 wasn't merged yet.

Refactor of #8 to use paramethers and headers
Added a `force` option to purge cache.
Added return types to some functions.

TODO:

- [ ] annotate all function arguments and return types